### PR TITLE
Random multiday test

### DIFF
--- a/comptoken/src/global_data/daily_distribution_data.rs
+++ b/comptoken/src/global_data/daily_distribution_data.rs
@@ -202,6 +202,8 @@ impl RoundEven for f64 {
 
 fn about_equal(left: f64, right: f64) -> bool {
     // this is technically wrong, but becuase it is only used for comparing against 0.5 it's good enough
+    // a more correct implementation would use relative error to accurately compare across a larger range
+    // of floats, but absolute error is fine for our purposes
     (left - right).abs() < f64::EPSILON
 }
 

--- a/comptoken/src/global_data/daily_distribution_data.rs
+++ b/comptoken/src/global_data/daily_distribution_data.rs
@@ -31,7 +31,7 @@ impl DailyDistributionData {
 
         let daily_mining_total = mint.supply - self.yesterday_supply;
         if daily_mining_total == 0 {
-            self.insert(0., 0);
+            self.insert(1., 0);
             return DailyDistributionValues {
                 interest_distribution: 0,
                 ubi_for_verified_humans: 0,
@@ -42,11 +42,13 @@ impl DailyDistributionData {
         msg!("High water mark increase: {}", high_water_mark_increase);
         self.high_water_mark += high_water_mark_increase;
         let total_daily_distribution = high_water_mark_increase * COMPTOKEN_DISTRIBUTION_MULTIPLIER;
+        msg!("Total daily distribution: {}", total_daily_distribution);
         let total_ubi_distribution = total_daily_distribution / 2;
         let verified_human_ubi_ratio = f64::min(
             1.,
             self.verified_humans as f64 * 2. / (FUTURE_UBI_VERIFIED_HUMANS as f64 + self.verified_humans as f64),
         );
+        msg!("Verified human UBI ratio: {}", verified_human_ubi_ratio);
         let mut distribution_values = DailyDistributionValues {
             interest_distribution: total_daily_distribution / 2,
             ubi_for_verified_humans: (total_ubi_distribution as f64 * verified_human_ubi_ratio) as u64,

--- a/test/component_tests.py
+++ b/test/component_tests.py
@@ -130,8 +130,8 @@ def parseArgs():
 
 if __name__ == "__main__":
     comptoken_tests: list[str] = [
-        "mint",
         "initializeComptokenProgram",
+        "mint", # testing to see if the timeout problem is mint or first test
         "createUserDataAccount",
         "proofSubmission",
         "getValidBlockhashes",

--- a/test/component_tests.py
+++ b/test/component_tests.py
@@ -141,6 +141,7 @@ if __name__ == "__main__":
         "growUserDataAccount",
         "shrinkUserDataAccount",
         "multidayDailyDistribution",
+        "randomMultidayDailyDistribution",
     ]
     transfer_hook_tests: list[str] = [
         "initialize_extra_account_meta_list",

--- a/test/compto-test-client/common.js
+++ b/test/compto-test-client/common.js
@@ -13,6 +13,7 @@ export const SEC_PER_DAY = 86_400n;
 export const BIG_NUMBER = 1_000_000_000;
 export const COMPTOKEN_DECIMALS = 0; // MAGIC NUMBER: remain consistent with comptoken.rs and full_deploy_test.py
 export const COMPTOKEN_DISTRIBUTION_MULTIPLIER = 146000n; // MAGIC NUMBER: remain consistent with constants.rs
+export const FUTURE_UBI_VERIFIED_HUMANS = 1_000_000_000; // MAGIC NUMBER: remain consistent with constants.rs
 
 // Read Cache Files
 import global_data_account from "../.cache/compto_global_data_account.json" assert { type: "json" };

--- a/test/compto-test-client/comptoken-tests/dailyDistributionEvent.js
+++ b/test/compto-test-client/comptoken-tests/dailyDistributionEvent.js
@@ -7,20 +7,19 @@ import {
     get_default_unpaid_verified_human_ubi_bank,
     GlobalDataAccount,
     MintAccount,
-    TokenAccount
 } from "../accounts.js";
 import { Assert } from "../assert.js";
 import {
-    DEFAULT_ANNOUNCE_TIME,
-    DEFAULT_DISTRIBUTION_TIME,
+    DEFAULT_START_TIME,
     SEC_PER_DAY,
 } from "../common.js";
-import { get_account, run_test, setup_test } from "../generic_test.js";
+import { Distribution, generic_daily_distribution_assertions, get_account, run_test, setup_test, YesterdaysAccounts } from "../generic_test.js";
 import { createDailyDistributionEventInstruction } from "../instruction.js";
 
 async function test_dailyDistributionEvent() {
+    const comptokens_minted = 10_000n;
     let original_comptoken_mint = get_default_comptoken_mint();
-    original_comptoken_mint.data.supply = 10_000n;
+    original_comptoken_mint.data.supply = comptokens_minted;
     let original_global_data_account = get_default_global_data();
     original_global_data_account.data.dailyDistributionData.verifiedHumans = 1n;
     const original_unpaid_interest_bank = get_default_unpaid_interest_bank();
@@ -30,62 +29,30 @@ async function test_dailyDistributionEvent() {
     const existing_accounts = [
         original_comptoken_mint, original_global_data_account, original_unpaid_interest_bank, original_unpaid_verified_human_ubi_bank, original_unpaid_future_ubi_bank,
     ];
+    const yesterdays_accounts = new YesterdaysAccounts(original_comptoken_mint, original_global_data_account, original_unpaid_interest_bank, original_unpaid_verified_human_ubi_bank, original_unpaid_future_ubi_bank);
 
     // 216_000 is mostly arbitrary, but it should roughly correspond to a days worth of slots
-    let context = await setup_test(existing_accounts, new Clock(216_000n, 0n, 0n, 0n, DEFAULT_DISTRIBUTION_TIME + SEC_PER_DAY + 1n));
+    let context = await setup_test(existing_accounts, new Clock(216_000n, 0n, 0n, 0n, DEFAULT_START_TIME + SEC_PER_DAY));
 
     let instructions = [await createDailyDistributionEventInstruction()];
 
     context = await run_test("dailyDistributionEvent", context, instructions, [context.payer], false, async (context, result) => {
+        await generic_daily_distribution_assertions(context, result, yesterdays_accounts, 1n, comptokens_minted);
+
         const final_comptoken_mint = await get_account(context, original_comptoken_mint.address, MintAccount);
         Assert.assert(final_comptoken_mint.data.supply > original_comptoken_mint.data.supply, "interest has been applied");
 
         const final_global_data_account = await get_account(context, original_global_data_account.address, GlobalDataAccount);
 
-        const final_valid_blockhash = final_global_data_account.data.validBlockhashes;
-        const original_valid_blockhash = original_global_data_account.data.validBlockhashes;
-        Assert.assertEqual(
-            final_valid_blockhash.announcedBlockhashTime,
-            DEFAULT_ANNOUNCE_TIME + SEC_PER_DAY,
-            "the announced blockhash time has been updated"
-        );
-        Assert.assertNotEqual(
-            final_valid_blockhash.announcedBlockhash,
-            original_valid_blockhash.announcedBlockhash,
-            "announced blockhash has changed"
-        ); // TODO: can the actual blockhash be predicted/gotten?
-        Assert.assertEqual(
-            final_valid_blockhash.validBlockhashTime, DEFAULT_DISTRIBUTION_TIME + SEC_PER_DAY, "the valid blockhash time has been updated"
-        );
-        Assert.assertNotEqual(final_valid_blockhash.validBlockhash, original_valid_blockhash.validBlockhash, "valid blockhash has changed");
-
         const final_daily_distribution_data = final_global_data_account.data.dailyDistributionData;
         const original_daily_distribution_data = original_global_data_account.data.dailyDistributionData;
         Assert.assert(final_daily_distribution_data.highWaterMark > original_daily_distribution_data.highWaterMark, "highwater mark has increased");
-        Assert.assertEqual(
-            final_daily_distribution_data.lastDailyDistributionTime,
-            DEFAULT_DISTRIBUTION_TIME + SEC_PER_DAY,
-            "last daily distribution time has updated"
-        );
-        Assert.assertEqual(
-            final_daily_distribution_data.yesterdaySupply,
-            final_comptoken_mint.data.supply,
-            "yesterdays supply is where the mint is after"
-        );
-        Assert.assertEqual(
-            final_daily_distribution_data.oldestHistoricValue,
-            original_daily_distribution_data.oldestHistoricValue + 1n,
-            "oldest interests has increased"
-        );
 
-        const final_interest_bank_account = await get_account(context, original_unpaid_interest_bank.address, TokenAccount);
-        Assert.assert(final_interest_bank_account.data.amount > original_unpaid_interest_bank.data.amount, "interest bank has increased");
+        const high_watermark_increase = comptokens_minted;
+        const distribution = new Distribution(final_daily_distribution_data, high_watermark_increase, yesterdays_accounts.unpaid_future_ubi_bank.data.amount);
 
-        const final_unpaid_verified_human_ubi_bank_account = await get_account(context, original_unpaid_verified_human_ubi_bank.address, TokenAccount);
-        Assert.assert(final_unpaid_verified_human_ubi_bank_account.data.amount > original_unpaid_verified_human_ubi_bank.data.amount, "Verified Human UBI bank has increased");
-
-        const final_unpaid_future_ubi_bank_account = await get_account(context, original_unpaid_future_ubi_bank.address, TokenAccount);
-        Assert.assert(final_unpaid_future_ubi_bank_account.data.amount > original_unpaid_future_ubi_bank.data.amount, "Future UBI bank has increased");
+        await distribution.assertInterestDistribution(context, yesterdays_accounts.unpaid_interest_bank, 0n);
+        await distribution.assertVerifiedHumanUBIDistribution(context, yesterdays_accounts.unpaid_verified_human_ubi_bank, 0n);
     });
 }
 

--- a/test/compto-test-client/comptoken-tests/dailyDistributionEvent.js
+++ b/test/compto-test-client/comptoken-tests/dailyDistributionEvent.js
@@ -37,7 +37,7 @@ async function test_dailyDistributionEvent() {
     let instructions = [await createDailyDistributionEventInstruction()];
 
     context = await run_test("dailyDistributionEvent", context, instructions, [context.payer], false, async (context, result) => {
-        await generic_daily_distribution_assertions(context, result, yesterdays_accounts, 1n, comptokens_minted);
+        await generic_daily_distribution_assertions(context, result, yesterdays_accounts, 1n, comptokens_minted, 0n, 0n);
 
         const final_comptoken_mint = await get_account(context, original_comptoken_mint.address, MintAccount);
         Assert.assert(final_comptoken_mint.data.supply > original_comptoken_mint.data.supply, "interest has been applied");
@@ -50,9 +50,6 @@ async function test_dailyDistributionEvent() {
 
         const high_watermark_increase = comptokens_minted;
         const distribution = new Distribution(final_daily_distribution_data, high_watermark_increase, yesterdays_accounts.unpaid_future_ubi_bank.data.amount);
-
-        await distribution.assertInterestDistribution(context, yesterdays_accounts.unpaid_interest_bank, 0n);
-        await distribution.assertVerifiedHumanUBIDistribution(context, yesterdays_accounts.unpaid_verified_human_ubi_bank, 0n);
     });
 }
 

--- a/test/compto-test-client/comptoken-tests/multidayDailyDistribution.js
+++ b/test/compto-test-client/comptoken-tests/multidayDailyDistribution.js
@@ -33,7 +33,7 @@ class MultidayDailyDistributionDaysParameters extends DaysParameters {
         await generic_daily_distribution_assertions(context, result, yesterdays_accounts, this.day, get_comptokens_minted(this.day));
         const current_global_data_account = await get_account(context, global_data_account_pubkey, GlobalDataAccount);
         const current_highwatermark = current_global_data_account.data.dailyDistributionData.highWaterMark;
-        const yesterdays_highwatermark = MultidayDailyDistributionDaysParameters.yesterdays_accounts.global_data_account.data.dailyDistributionData.highWaterMark;
+        const yesterdays_highwatermark = yesterdays_accounts.global_data_account.data.dailyDistributionData.highWaterMark;
         const highwatermark_increase = current_highwatermark - yesterdays_highwatermark;
 
         // every 10 days the mining increases, so the highwatermark should increase, and comptokens should be distributed

--- a/test/compto-test-client/comptoken-tests/multidayDailyDistribution.js
+++ b/test/compto-test-client/comptoken-tests/multidayDailyDistribution.js
@@ -16,7 +16,7 @@ import {
     interest_bank_account_pubkey,
     verified_human_ubi_bank_account_pubkey,
 } from "../common.js";
-import { DaysParameters, Distribution, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test } from "../generic_test.js";
+import { DaysParameters, Distribution, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test, YesterdaysAccounts } from "../generic_test.js";
 import { createDailyDistributionEventInstruction, createTestInstruction } from "../instruction.js";
 
 // arbitrary function to produce "how many comptokens are minted on a given day" test data
@@ -26,12 +26,7 @@ function get_comptokens_minted(current_day) {
 }
 
 class MultidayDailyDistributionDaysParameters extends DaysParameters {
-    static yesterdays_accounts = {
-        global_data_account: get_default_global_data(),
-        unpaid_interest_bank: get_default_unpaid_interest_bank(),
-        unpaid_verified_human_ubi_bank: get_default_unpaid_verified_human_ubi_bank(),
-        unpaid_future_ubi_bank: get_default_unpaid_future_ubi_bank(),
-    };
+    static yesterdays_accounts = new YesterdaysAccounts();
 
     testuser;
     payer;
@@ -77,12 +72,7 @@ class MultidayDailyDistributionDaysParameters extends DaysParameters {
             "unpaid future ubi bank should increase by future_ubi"
         );
 
-        MultidayDailyDistributionDaysParameters.yesterdays_accounts = {
-            global_data_account: current_global_data_account,
-            unpaid_interest_bank: current_unpaid_interest_bank,
-            unpaid_verified_human_ubi_bank: current_unpaid_verified_human_ubi_bank,
-            unpaid_future_ubi_bank: current_unpaid_future_ubi_bank,
-        }
+        MultidayDailyDistributionDaysParameters.yesterdays_accounts = await YesterdaysAccounts.get_accounts(context);
     }
 
     constructor(day, testuser, payer, user_comptoken_token_account_address) {

--- a/test/compto-test-client/comptoken-tests/multidayDailyDistribution.js
+++ b/test/compto-test-client/comptoken-tests/multidayDailyDistribution.js
@@ -16,7 +16,7 @@ import {
     interest_bank_account_pubkey,
     verified_human_ubi_bank_account_pubkey,
 } from "../common.js";
-import { DaysParameters, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test } from "../generic_test.js";
+import { DaysParameters, Distribution, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test } from "../generic_test.js";
 import { createDailyDistributionEventInstruction, createTestInstruction } from "../instruction.js";
 
 // arbitrary function to produce "how many comptokens are minted on a given day" test data
@@ -56,6 +56,26 @@ class MultidayDailyDistributionDaysParameters extends DaysParameters {
         const current_unpaid_interest_bank = await get_account(context, interest_bank_account_pubkey, TokenAccount);
         const current_unpaid_verified_human_ubi_bank = await get_account(context, verified_human_ubi_bank_account_pubkey, TokenAccount);
         const current_unpaid_future_ubi_bank = await get_account(context, future_ubi_bank_account_pubkey, TokenAccount);
+
+        const distribution = new Distribution(current_global_data_account.data.dailyDistributionData, highwatermark_increase, MultidayDailyDistributionDaysParameters.yesterdays_accounts.unpaid_future_ubi_bank.data.amount);
+
+        Assert.assertEqual(
+            MultidayDailyDistributionDaysParameters.yesterdays_accounts.unpaid_interest_bank.data.amount + distribution.interest,
+            current_unpaid_interest_bank.data.amount,
+            "unpaid interest bank should increase by interest_distribution"
+        );
+
+        Assert.assertEqual(
+            MultidayDailyDistributionDaysParameters.yesterdays_accounts.unpaid_verified_human_ubi_bank.data.amount + distribution.verified_human_ubi,
+            current_unpaid_verified_human_ubi_bank.data.amount,
+            "unpaid verified human ubi bank should increase by verified_human_ubi"
+        );
+
+        Assert.assertEqual(
+            MultidayDailyDistributionDaysParameters.yesterdays_accounts.unpaid_future_ubi_bank.data.amount + distribution.future_ubi,
+            current_unpaid_future_ubi_bank.data.amount,
+            "unpaid future ubi bank should increase by future_ubi"
+        );
 
         MultidayDailyDistributionDaysParameters.yesterdays_accounts = {
             global_data_account: current_global_data_account,

--- a/test/compto-test-client/comptoken-tests/multidayDailyDistribution.js
+++ b/test/compto-test-client/comptoken-tests/multidayDailyDistribution.js
@@ -30,7 +30,7 @@ class MultidayDailyDistributionDaysParameters extends DaysParameters {
 
     assert_fn = async (context, result) => {
         const yesterdays_accounts = MultidayDailyDistributionDaysParameters.yesterdays_accounts;
-        await generic_daily_distribution_assertions(context, result, yesterdays_accounts, this.day, get_comptokens_minted(this.day));
+        await generic_daily_distribution_assertions(context, result, yesterdays_accounts, this.day, get_comptokens_minted(this.day), 0n, 0n);
         const current_global_data_account = await get_account(context, global_data_account_pubkey, GlobalDataAccount);
         const current_highwatermark = current_global_data_account.data.dailyDistributionData.highWaterMark;
         const yesterdays_highwatermark = yesterdays_accounts.global_data_account.data.dailyDistributionData.highWaterMark;

--- a/test/compto-test-client/comptoken-tests/multidayDailyDistribution.js
+++ b/test/compto-test-client/comptoken-tests/multidayDailyDistribution.js
@@ -7,14 +7,10 @@ import {
     get_default_unpaid_interest_bank,
     get_default_unpaid_verified_human_ubi_bank,
     GlobalDataAccount,
-    TokenAccount,
 } from "../accounts.js";
 import { Assert, } from "../assert.js";
 import {
-    future_ubi_bank_account_pubkey,
     global_data_account_pubkey,
-    interest_bank_account_pubkey,
-    verified_human_ubi_bank_account_pubkey,
 } from "../common.js";
 import { DaysParameters, Distribution, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test, YesterdaysAccounts } from "../generic_test.js";
 import { createDailyDistributionEventInstruction, createTestInstruction } from "../instruction.js";
@@ -47,8 +43,6 @@ class MultidayDailyDistributionDaysParameters extends DaysParameters {
         else {
             Assert.assertEqual(highwatermark_increase, 0n, "highwatermark should increase by 0");
         }
-
-        const current_unpaid_future_ubi_bank = await get_account(context, future_ubi_bank_account_pubkey, TokenAccount);
 
         const distribution = new Distribution(current_global_data_account.data.dailyDistributionData, highwatermark_increase, yesterdays_accounts.unpaid_future_ubi_bank.data.amount);
 

--- a/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
+++ b/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
@@ -7,10 +7,8 @@ import {
     get_default_unpaid_interest_bank,
     get_default_unpaid_verified_human_ubi_bank,
     GlobalDataAccount,
-    TokenAccount,
 } from "../accounts.js";
-import { Assert } from "../assert.js";
-import { future_ubi_bank_account_pubkey, global_data_account_pubkey, interest_bank_account_pubkey, verified_human_ubi_bank_account_pubkey } from "../common.js";
+import { global_data_account_pubkey } from "../common.js";
 import { DaysParameters, Distribution, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test, YesterdaysAccounts } from "../generic_test.js";
 import { createDailyDistributionEventInstruction, createTestInstruction } from "../instruction.js";
 import { debug } from "../parse_args.js";

--- a/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
+++ b/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
@@ -11,17 +11,12 @@ import {
 } from "../accounts.js";
 import { Assert } from "../assert.js";
 import { future_ubi_bank_account_pubkey, global_data_account_pubkey, interest_bank_account_pubkey, verified_human_ubi_bank_account_pubkey } from "../common.js";
-import { DaysParameters, Distribution, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test } from "../generic_test.js";
+import { DaysParameters, Distribution, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test, YesterdaysAccounts } from "../generic_test.js";
 import { createDailyDistributionEventInstruction, createTestInstruction } from "../instruction.js";
 import { debug } from "../parse_args.js";
 
 class RandomMultidayDailyDistributionDaysParameters extends DaysParameters {
-    static yesterdays_accounts = {
-        global_data_account: get_default_global_data(),
-        unpaid_interest_bank: get_default_unpaid_interest_bank(),
-        unpaid_verified_human_ubi_bank: get_default_unpaid_verified_human_ubi_bank(),
-        unpaid_future_ubi_bank: get_default_unpaid_future_ubi_bank(),
-    };
+    static yesterdays_accounts = new YesterdaysAccounts();
 
     testuser;
     payer;
@@ -68,12 +63,7 @@ class RandomMultidayDailyDistributionDaysParameters extends DaysParameters {
             "unpaid future ubi bank should increase by future_ubi"
         );
 
-        RandomMultidayDailyDistributionDaysParameters.yesterdays_accounts = {
-            global_data_account: current_global_data_account,
-            unpaid_interest_bank: current_unpaid_interest_bank,
-            unpaid_verified_human_ubi_bank: current_unpaid_verified_human_ubi_bank,
-            unpaid_future_ubi_bank: current_unpaid_future_ubi_bank,
-        }
+        RandomMultidayDailyDistributionDaysParameters.yesterdays_accounts = await YesterdaysAccounts.get_accounts(context);
     }
 
     async get_setup_instructions() {

--- a/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
+++ b/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
@@ -9,8 +9,9 @@ import {
     GlobalDataAccount,
     TokenAccount,
 } from "../accounts.js";
+import { Assert } from "../assert.js";
 import { future_ubi_bank_account_pubkey, global_data_account_pubkey, interest_bank_account_pubkey, verified_human_ubi_bank_account_pubkey } from "../common.js";
-import { DaysParameters, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test } from "../generic_test.js";
+import { DaysParameters, Distribution, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test } from "../generic_test.js";
 import { createDailyDistributionEventInstruction, createTestInstruction } from "../instruction.js";
 import { debug } from "../parse_args.js";
 
@@ -42,6 +43,30 @@ class RandomMultidayDailyDistributionDaysParameters extends DaysParameters {
         const current_unpaid_interest_bank = await get_account(context, interest_bank_account_pubkey, TokenAccount);
         const current_unpaid_verified_human_ubi_bank = await get_account(context, verified_human_ubi_bank_account_pubkey, TokenAccount);
         const current_unpaid_future_ubi_bank = await get_account(context, future_ubi_bank_account_pubkey, TokenAccount);
+
+        const current_highwatermark = current_global_data_account.data.dailyDistributionData.highWaterMark;
+        const yesterdays_highwatermark = RandomMultidayDailyDistributionDaysParameters.yesterdays_accounts.global_data_account.data.dailyDistributionData.highWaterMark;
+        const highwatermark_increase = current_highwatermark - yesterdays_highwatermark;
+
+        const distribution = new Distribution(current_global_data_account.data.dailyDistributionData, highwatermark_increase, RandomMultidayDailyDistributionDaysParameters.yesterdays_accounts.unpaid_future_ubi_bank.data.amount);
+
+        Assert.assertEqual(
+            RandomMultidayDailyDistributionDaysParameters.yesterdays_accounts.unpaid_interest_bank.data.amount + distribution.interest,
+            current_unpaid_interest_bank.data.amount,
+            "unpaid interest bank should increase by interest_distribution"
+        );
+
+        Assert.assertEqual(
+            RandomMultidayDailyDistributionDaysParameters.yesterdays_accounts.unpaid_verified_human_ubi_bank.data.amount + distribution.verified_human_ubi,
+            current_unpaid_verified_human_ubi_bank.data.amount,
+            "unpaid verified human ubi bank should increase by verified_human_ubi"
+        );
+
+        Assert.assertEqual(
+            RandomMultidayDailyDistributionDaysParameters.yesterdays_accounts.unpaid_future_ubi_bank.data.amount + distribution.future_ubi,
+            current_unpaid_future_ubi_bank.data.amount,
+            "unpaid future ubi bank should increase by future_ubi"
+        );
 
         RandomMultidayDailyDistributionDaysParameters.yesterdays_accounts = {
             global_data_account: current_global_data_account,

--- a/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
+++ b/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
@@ -7,14 +7,20 @@ import {
     get_default_unpaid_interest_bank,
     get_default_unpaid_verified_human_ubi_bank,
     GlobalDataAccount,
+    TokenAccount,
 } from "../accounts.js";
-import { global_data_account_pubkey } from "../common.js";
+import { future_ubi_bank_account_pubkey, global_data_account_pubkey, interest_bank_account_pubkey, verified_human_ubi_bank_account_pubkey } from "../common.js";
 import { DaysParameters, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test } from "../generic_test.js";
 import { createDailyDistributionEventInstruction, createTestInstruction } from "../instruction.js";
 import { debug } from "../parse_args.js";
 
 class RandomMultidayDailyDistributionDaysParameters extends DaysParameters {
-    static yesterdays_global_daya_account = get_default_global_data();
+    static yesterdays_accounts = {
+        global_data_account: get_default_global_data(),
+        unpaid_interest_bank: get_default_unpaid_interest_bank(),
+        unpaid_verified_human_ubi_bank: get_default_unpaid_verified_human_ubi_bank(),
+        unpaid_future_ubi_bank: get_default_unpaid_future_ubi_bank(),
+    };
 
     testuser;
     payer;
@@ -30,8 +36,19 @@ class RandomMultidayDailyDistributionDaysParameters extends DaysParameters {
     }
 
     assert_fn = async (context, result) => {
-        await generic_daily_distribution_assertions(context, result, RandomMultidayDailyDistributionDaysParameters.yesterdays_global_daya_account, this.day, this.comptokens_minted);
-        RandomMultidayDailyDistributionDaysParameters.yesterdays_global_daya_account = await get_account(context, global_data_account_pubkey, GlobalDataAccount);
+        await generic_daily_distribution_assertions(context, result, RandomMultidayDailyDistributionDaysParameters.yesterdays_accounts, this.day, this.comptokens_minted);
+
+        const current_global_data_account = await get_account(context, global_data_account_pubkey, GlobalDataAccount);
+        const current_unpaid_interest_bank = await get_account(context, interest_bank_account_pubkey, TokenAccount);
+        const current_unpaid_verified_human_ubi_bank = await get_account(context, verified_human_ubi_bank_account_pubkey, TokenAccount);
+        const current_unpaid_future_ubi_bank = await get_account(context, future_ubi_bank_account_pubkey, TokenAccount);
+
+        RandomMultidayDailyDistributionDaysParameters.yesterdays_accounts = {
+            global_data_account: current_global_data_account,
+            unpaid_interest_bank: current_unpaid_interest_bank,
+            unpaid_verified_human_ubi_bank: current_unpaid_verified_human_ubi_bank,
+            unpaid_future_ubi_bank: current_unpaid_future_ubi_bank,
+        }
     }
 
     async get_setup_instructions() {

--- a/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
+++ b/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
@@ -1,0 +1,131 @@
+import { Keypair, PublicKey } from "@solana/web3.js";
+import {
+    get_default_comptoken_mint,
+    get_default_comptoken_token_account,
+    get_default_global_data,
+    get_default_unpaid_future_ubi_bank,
+    get_default_unpaid_interest_bank,
+    get_default_unpaid_verified_human_ubi_bank,
+    GlobalDataAccount,
+} from "../accounts.js";
+import { global_data_account_pubkey } from "../common.js";
+import { DaysParameters, generic_daily_distribution_assertions, get_account, run_multiday_test, setup_test } from "../generic_test.js";
+import { createDailyDistributionEventInstruction, createTestInstruction } from "../instruction.js";
+import { debug } from "../parse_args.js";
+
+class RandomMultidayDailyDistributionDaysParameters extends DaysParameters {
+    static yesterdays_global_daya_account = get_default_global_data();
+
+    testuser;
+    payer;
+    user_comptoken_token_account_address;
+    comptokens_minted;
+
+    constructor(day, testuser, payer, user_comptoken_token_account_address, comptokens_minted) {
+        super(day);
+        this.testuser = testuser;
+        this.payer = payer;
+        this.user_comptoken_token_account_address = user_comptoken_token_account_address;
+        this.comptokens_minted = BigInt(comptokens_minted);
+    }
+
+    assert_fn = async (context, result) => {
+        await generic_daily_distribution_assertions(context, result, RandomMultidayDailyDistributionDaysParameters.yesterdays_global_daya_account, this.day, this.comptokens_minted);
+        RandomMultidayDailyDistributionDaysParameters.yesterdays_global_daya_account = await get_account(context, global_data_account_pubkey, GlobalDataAccount);
+    }
+
+    async get_setup_instructions() {
+        return [await createTestInstruction(this.testuser.publicKey, this.user_comptoken_token_account_address, this.comptokens_minted)];
+    }
+    async get_setup_signers() {
+        return [this.payer, this.testuser]
+    }
+    async get_instructions() {
+        return [await createDailyDistributionEventInstruction()];
+    }
+    async get_signers() {
+        return [this.payer];
+    }
+}
+
+async function test_multidayDailyDistribution() {
+    // this is a test for daily distributions only, none of the other features are tested
+    const testuser = Keypair.generate();
+    const user_comptoken_token_account = get_default_comptoken_token_account(PublicKey.unique(), testuser.publicKey);
+    const original_comptoken_mint = get_default_comptoken_mint();
+    const original_global_data_account = get_default_global_data();
+    const original_unpaid_interest_bank = get_default_unpaid_interest_bank();
+    const original_unpaid_verified_human_ubi_bank = get_default_unpaid_verified_human_ubi_bank();
+    const original_unpaid_future_ubi_bank = get_default_unpaid_future_ubi_bank();
+
+    const existing_accounts = [
+        original_comptoken_mint, original_global_data_account, original_unpaid_interest_bank, original_unpaid_verified_human_ubi_bank,
+        original_unpaid_future_ubi_bank, user_comptoken_token_account
+    ];
+
+    let context = await setup_test(existing_accounts);
+
+    let random_walk = generate_random_walk(100, 5, 0, Infinity, 1);
+
+    debug(random_walk);
+    log_random_walk_stats(random_walk);
+
+    let days_parameters_arr = Array.from(random_walk, (v, i) => {
+        return new RandomMultidayDailyDistributionDaysParameters(i + 1, testuser, context.payer, user_comptoken_token_account.address, v);
+    });
+
+    await run_multiday_test("multiday_daily_distribution_1", context, days_parameters_arr);
+}
+
+(async () => { await test_multidayDailyDistribution(); })();
+
+function generate_random_walk(length, max_step = 1, min = -Infinity, max = Infinity, bias = 0, start = 0) {
+    let arr = new Array(length);
+    let current = start;
+    for (let i = 0; i < length; ++i) {
+        let step = Math.floor(rng() * (max_step * 2 + bias)) - max_step;
+        current += step;
+        current = Math.max(Math.min(current, max), min);
+        arr[i] = current;
+    }
+    return arr;
+}
+
+/**
+ * 
+ * @param {number[]} random_walk 
+ */
+function log_random_walk_stats(random_walk) {
+    random_walk = random_walk.slice(); // copy array
+    random_walk.sort();
+    const min = random_walk[0];
+    const max = random_walk[random_walk.length - 1];
+    const avg = random_walk.reduce((sum, elem, i) => sum + elem) / random_walk.length;
+    const median = random_walk[Math.floor(random_walk.length / 2)];
+    debug("min: ", min);
+    debug("max: ", max);
+    debug("avg: ", avg);
+    debug("median: ", median);
+}
+
+// from https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript/47593316#47593316
+function sfc32(a, b, c, d) {
+    return function () {
+        a |= 0; b |= 0; c |= 0; d |= 0;
+        let t = (a + b | 0) + d | 0;
+        d = d + 1 | 0;
+        a = b ^ b >>> 9;
+        b = c + (c << 3) | 0;
+        c = (c << 21 | c >>> 11);
+        c = c + t | 0;
+        return (t >>> 0) / 4294967296;
+    }
+}
+
+function seedgen() {
+    return (Math.random() * 2 ** 32) >>> 0;
+}
+
+const seed = [seedgen(), seedgen(), seedgen(), seedgen()];
+console.log("seed for rng: ", seed);
+const rng = sfc32(seed[0], seed[1], seed[2], seed[3]);

--- a/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
+++ b/test/compto-test-client/comptoken-tests/randomMultidayDailyDistribution.js
@@ -31,7 +31,7 @@ class RandomMultidayDailyDistributionDaysParameters extends DaysParameters {
 
     assert_fn = async (context, result) => {
         const yesterdays_accounts = RandomMultidayDailyDistributionDaysParameters.yesterdays_accounts;
-        await generic_daily_distribution_assertions(context, result, yesterdays_accounts, this.day, this.comptokens_minted);
+        await generic_daily_distribution_assertions(context, result, yesterdays_accounts, this.day, this.comptokens_minted, 0n, 0n);
 
         const current_global_data_account = await get_account(context, global_data_account_pubkey, GlobalDataAccount);
 

--- a/test/compto-test-client/generic_test.js
+++ b/test/compto-test-client/generic_test.js
@@ -174,10 +174,10 @@ export class Distribution {
 
         const comptokens_per_new_verified_human = yesterdays_accounts.unpaid_future_ubi_bank.data.amount / (BigInt(FUTURE_UBI_VERIFIED_HUMANS) - yesterdays_verified_humans);
 
-        const future_ubi_distributed = new_verified_humans * comptokens_per_new_verified_human;
+        const future_ubi_paid = new_verified_humans * comptokens_per_new_verified_human;
 
         Assert.assertEqual(
-            yesterdays_accounts.unpaid_future_ubi_bank.data.amount + this.future_ubi - future_ubi_distributed,
+            yesterdays_accounts.unpaid_future_ubi_bank.data.amount + this.future_ubi - future_ubi_paid,
             current_unpaid_future_ubi_bank.data.amount,
             "unpaid future ubi bank should increase by future_ubi"
         );

--- a/test/compto-test-client/generic_test.js
+++ b/test/compto-test-client/generic_test.js
@@ -286,9 +286,11 @@ export async function run_multiday_test(name, context, days_parameters_arr) {
     }
 }
 
-export async function generic_daily_distribution_assertions(context, result, yesterdays_accounts, day, comptokens_minted) {
+export async function generic_daily_distribution_assertions(context, result, yesterdays_accounts, day, comptokens_minted, interest_paid, verified_human_ubi_paid) {
     comptokens_minted = BigInt(comptokens_minted);
     day = BigInt(day);
+    interest_paid = BigInt(interest_paid);
+    verified_human_ubi_paid = BigInt(verified_human_ubi_paid);
 
     const current_comptoken_mint = await get_account(context, comptoken_mint_pubkey, MintAccount);
     const current_global_data_account = await get_account(context, global_data_account_pubkey, GlobalDataAccount);
@@ -348,6 +350,8 @@ export async function generic_daily_distribution_assertions(context, result, yes
         "supply should increase by comptokens_minted yesterday + total distribution"
     );
 
+    await distribution.assertInterestDistribution(context, yesterdays_accounts.unpaid_interest_bank, interest_paid);
+    await distribution.assertVerifiedHumanUBIDistribution(context, yesterdays_accounts.unpaid_verified_human_ubi_bank, verified_human_ubi_paid);
     await distribution.assertFutureUBIDistribution(context, yesterdays_accounts);
 }
 

--- a/test/compto-test-client/generic_test.js
+++ b/test/compto-test-client/generic_test.js
@@ -217,11 +217,79 @@ export async function generic_daily_distribution_assertions(context, result, yes
     const yesterdays_highwatermark = yesterdays_accounts.global_data_account.data.dailyDistributionData.highWaterMark;
     const highwatermark_increase = current_highwatermark - yesterdays_highwatermark;
 
+    const distribution = new Distribution(current_daily_distribution_data, highwatermark_increase, yesterdays_accounts.unpaid_future_ubi_bank.data.amount);
+
+    debug("distribution: %d", distribution.total());
+
     Assert.assertEqual(
         supply_increase,
-        comptokens_minted + highwatermark_increase * COMPTOKEN_DISTRIBUTION_MULTIPLIER,
+        comptokens_minted + distribution.total(),
         "supply should increase by comptokens_minted yesterday + high_watermark_increase * COMPTOKEN_DISTRIBUTION_MULTIPLIER"
     );
+}
+
+export class Distribution {
+    interest;
+    future_ubi;
+    verified_human_ubi;
+
+    constructor(daily_distribution_data, high_watermark_increase, unpaid_future_ubi_amount) {
+
+        daily_distribution_data.historicDistributions.forEach(element => {
+            info("interestRate: %f", element.interestRate);
+        });
+        const verified_humans = Number(daily_distribution_data.verifiedHumans);
+        const interest_rate = daily_distribution_data.historicDistributions[daily_distribution_data.oldestHistoricValue - 1n].interestRate - 1;
+        debug("interest_rate: %f", interest_rate);
+
+        const original_distribution = high_watermark_increase * COMPTOKEN_DISTRIBUTION_MULTIPLIER;
+        debug("original_distribution: %d", original_distribution);
+        let interest_distribution = original_distribution / 2n;
+        debug("interest_distribution before UBI Interest: %d", interest_distribution);
+        const ubi_distribution = original_distribution / 2n;
+        debug("ubi_distribution before UBI Interest: %d", ubi_distribution);
+
+        const unchecked_verified_human_proportion = 2 * verified_humans / (FUTURE_UBI_VERIFIED_HUMANS + verified_humans);
+        const verified_human_proportion = Math.min(unchecked_verified_human_proportion, 1);
+        debug("verified_human_proportion: %f", verified_human_proportion);
+        const verified_human_ubi_distribution = BigInt(Number(ubi_distribution) * verified_human_proportion);
+        debug("verified_human_ubi before UBI Interest: %d", verified_human_ubi_distribution);
+        let future_ubi_distribution = ubi_distribution - verified_human_ubi_distribution;
+        debug("future_ubi before UBI Interest: %d", future_ubi_distribution);
+
+        let future_ubi_interest = BigInt(round_ties_even(Number(unpaid_future_ubi_amount) * interest_rate));
+        future_ubi_distribution += future_ubi_interest;
+        interest_distribution -= future_ubi_interest;
+
+        debug("interest_distribution: %d", interest_distribution);
+        debug("ubi_distribution: %d", ubi_distribution + future_ubi_interest);
+        debug("verified_human_ubi: %d", verified_human_ubi_distribution);
+        debug("future_ubi: %d", future_ubi_distribution);
+
+
+        this.interest = interest_distribution;
+        this.future_ubi = future_ubi_distribution;
+        this.verified_human_ubi = verified_human_ubi_distribution;
+    }
+
+    total() {
+        return this.interest + this.future_ubi + this.verified_human_ubi;
+    }
+}
+
+function round_ties_even(number) {
+    const result = Math.round(number);
+    const fract = Math.abs(number - result);
+    if (float_equals(fract, 0.5) && result % 2 !== 0) {
+        return Math.trunc(number);
+    } else {
+        return result;
+    }
+}
+
+function float_equals(a, b) {
+    const epsilon = 1e-10; // what copilot autofilled
+    return a < b + epsilon && a > b - epsilon;
 }
 
 /**

--- a/test/compto-test-client/generic_test.js
+++ b/test/compto-test-client/generic_test.js
@@ -122,7 +122,7 @@ export class Distribution {
         const unchecked_verified_human_proportion = 2 * verified_humans / (FUTURE_UBI_VERIFIED_HUMANS + verified_humans);
         const verified_human_proportion = Math.min(unchecked_verified_human_proportion, 1);
         debug("verified_human_proportion: %f", verified_human_proportion);
-        const verified_human_ubi_distribution = BigInt(Number(ubi_distribution) * verified_human_proportion);
+        const verified_human_ubi_distribution = BigInt(round_ties_even(Number(ubi_distribution) * verified_human_proportion));
         debug("verified_human_ubi before UBI Interest: %d", verified_human_ubi_distribution);
         let future_ubi_distribution = ubi_distribution - verified_human_ubi_distribution;
         debug("future_ubi before UBI Interest: %d", future_ubi_distribution);
@@ -345,7 +345,7 @@ export async function generic_daily_distribution_assertions(context, result, yes
     Assert.assertEqual(
         supply_increase,
         comptokens_minted + distribution.total(),
-        "supply should increase by comptokens_minted yesterday + high_watermark_increase * COMPTOKEN_DISTRIBUTION_MULTIPLIER"
+        "supply should increase by comptokens_minted yesterday + total distribution"
     );
 
     await distribution.assertFutureUBIDistribution(context, yesterdays_accounts);
@@ -362,8 +362,8 @@ function round_ties_even(number) {
 }
 
 function float_equals(a, b) {
-    const epsilon = 1e-10; // what copilot autofilled
-    return a < b + epsilon && a > b - epsilon;
+    const epsilon = 2.220446049250313e-16; // from https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.EPSILON
+    return Math.abs(a - b) < epsilon;
 }
 
 /**


### PR DESCRIPTION
create another simple multiday bankrun test. It uses a random walk to decide the amount minted each day. 