### PR TITLE
Repeat verification prevention 2 storage

### DIFF
--- a/comptoken-utils/src/comptoken_utils.rs
+++ b/comptoken-utils/src/comptoken_utils.rs
@@ -2,7 +2,11 @@ pub mod user_data;
 pub mod verify_accounts;
 
 use spl_token_2022::solana_program::{
-    entrypoint::ProgramResult, instruction::Instruction, program::invoke_signed, pubkey::Pubkey, system_instruction,
+    entrypoint::ProgramResult,
+    instruction::Instruction,
+    program::{invoke, invoke_signed},
+    pubkey::Pubkey,
+    system_instruction,
 };
 
 #[cfg(not(feature = "test_mock"))]
@@ -19,6 +23,12 @@ pub fn create_pda<'a>(
     let create_acct_instr = system_instruction::create_account(payer.key, new_account.key, lamports, space, owner);
     // The PDA that is being created must sign for its own creation.
     invoke_signed_verified(&create_acct_instr, &[payer, new_account], signers_seeds)
+}
+
+pub fn invoke_verified(instruction: &Instruction, accounts: &[&VerifiedAccountInfo]) -> ProgramResult {
+    // Convert VerifiedAccountInfo references to AccountInfo references
+    let account_refs: Vec<_> = accounts.iter().map(|acct| acct.0.clone()).collect();
+    invoke(instruction, &account_refs)
 }
 
 pub fn invoke_signed_verified(

--- a/comptoken/notes.md
+++ b/comptoken/notes.md
@@ -1,0 +1,46 @@
+
+payer
+root?
+config?
+recipient - new account to verify - wallet - how to handle users who wish to use existing accounts? how to handle users who wish to migrate away?
+nullifier?
+world_id_program
+system_program
+
+root_hash [u8; 32]
+nullifier_hash [u8;32]
+proof [u8; 256]
+
+call verify_groth16_proof:
+    program: world_id_program
+    accounts: [
+        root: PDA(b'Root', root_hash, verification_type),
+        config: PDA(b'Config'),
+    ]
+    data: [
+        root_hash: [u8; 32],
+        _verification_type: [u8; 1], // "orb"? probably? // 1 for orb only?
+        signal_hash: [u8; 32], // hashed recipient's public key [0, ...hash(pubkey)[0..31]] 
+        nullifier_hash: [u8; 32],
+        external_nullifier_hash: [u8; 32], // from action, must be globally unique, so Compto_UBI_Signup?
+        proof: [u8; 256],
+    ]
+    
+``` rust
+// ensures the hash is on the elliptic curve for the ZK proofs
+fn hash_to_field(val: &[u8]) -> [u8; 32] {
+    let hash_result = hash(input).to_bytes();
+    let big_int: U256 = U256::from_be_bytes(hash_result);
+    let shifted: U256 = big_int >> 8;
+    shifted.to_be_bytes()
+}
+
+fn app_id_action_to_external_nullifier_hash(app_id: &str, action: &str) -> [u8; 32] {
+    let app_hash = hash_to_field(app_id.as_bytes());
+    let mut combined = app_hash.to_vec();
+    combined.extend_from_slice(action.as_bytes());
+    hash_to_field(&combined)
+}
+```
+
+verify proof doesn't gurantee uniqueness

--- a/comptoken/src/comptoken.rs
+++ b/comptoken/src/comptoken.rs
@@ -10,8 +10,15 @@ use spl_token_2022::{
     instruction::mint_to,
     onchain,
     solana_program::{
-        account_info::AccountInfo, entrypoint, entrypoint::MAX_PERMITTED_DATA_INCREASE, hash::HASH_BYTES,
-        instruction::AccountMeta, msg, program::set_return_data, program_error::ProgramError, pubkey::Pubkey,
+        account_info::AccountInfo,
+        entrypoint,
+        entrypoint::MAX_PERMITTED_DATA_INCREASE,
+        hash::{self, Hash, HASH_BYTES},
+        instruction::{AccountMeta, Instruction},
+        msg,
+        program::set_return_data,
+        program_error::ProgramError,
+        pubkey::Pubkey,
         system_instruction,
     },
     state::{Account, Mint},
@@ -625,7 +632,7 @@ pub fn realloc_user_data(program_id: &Pubkey, accounts: &[AccountInfo], instruct
     user_data_account.realloc(new_size, false)
 }
 
-pub fn verify_human(program_id: &Pubkey, accounts: &[AccountInfo], _instruction_data: &[u8]) -> ProgramResult {
+pub fn verify_human(program_id: &Pubkey, accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     //  Account Order
     //      [] Comptoken Program
     //      [] Comptoken Mint
@@ -638,6 +645,17 @@ pub fn verify_human(program_id: &Pubkey, accounts: &[AccountInfo], _instruction_
     //      [] transfer hook program
     //      [] extra account metas account
     //      [] Solana Token 2022 Program
+    // data:
+    //      32 bytes - root hash
+    //      32 bytes - nullifier hash
+    //      256 bytes - proof
+    const PROOF_BYTES: usize = 256;
+    const VERIFICATION_TYPE: [u8; 1] = [0_u8]; // 0 for query-based verification (maybe?)
+
+    let (root_hash, instruction_data) = get_next_data(instruction_data, HASH_BYTES, Hash::new);
+    let (nullifier_hash, instruction_data) = get_next_data(instruction_data, HASH_BYTES, Hash::new);
+    let (proof, instruction_data) = get_next_data(instruction_data, PROOF_BYTES, |d| d);
+    assert!(instruction_data.is_empty(), "instruction data is not empty");
 
     let verified_accounts = verify_accounts(
         accounts,
@@ -668,6 +686,7 @@ pub fn verify_human(program_id: &Pubkey, accounts: &[AccountInfo], _instruction_
     let global_data_account = verified_accounts.global_data.unwrap();
     let unpaid_future_ubi_bank_account = verified_accounts.future_ubi_bank.unwrap();
     let future_ubi_bank_data = verified_accounts.future_ubi_bank_data.unwrap();
+    let user_wallet = verified_accounts.user_wallet.unwrap();
     let user_comptoken_token_account = verified_accounts.user_comptoken_token_account.unwrap();
     let user_data_account = verified_accounts.user_data.unwrap();
     let transfer_hook_program = verified_accounts.transfer_hook_program.unwrap();
@@ -678,10 +697,42 @@ pub fn verify_human(program_id: &Pubkey, accounts: &[AccountInfo], _instruction_
     let world_id_config = verified_accounts.world_id_config.unwrap();
     let world_id_nullifier = verified_accounts.world_id_nullifier.unwrap();
 
-    todo!("cpi to worldcoin to verify human");
+    // 1. verify unique nullifier hash
+
     // TODO
-    // also... what about when people die?
-    // also... what happens about double attempts to verify?
+    // TODO what to do when people die?
+
+    // 2. cpi to world id program
+    const APP_ID: &str = "comptoken";
+    const ACTION: &str = "COMPTO";
+    let external_nullifier_hash = app_id_to_external_nullifier_hash(APP_ID, ACTION); // TODO: make this a constant
+    let signal_bytes = user_wallet.key.to_bytes();
+    let signal_hash = hash_to_field(&signal_bytes);
+
+    let mut world_id_cpi_data = Vec::with_capacity(385);
+    world_id_cpi_data.extend_from_slice(&[54, 190, 59, 14, 54, 75, 155, 6]); // discriminator https://github.com/wormholelabs-xyz/solana-world-id-onchain-template/blob/main/idls/solana_world_id_program.ts#L801-L808
+    world_id_cpi_data.extend_from_slice(root_hash.as_ref());
+    world_id_cpi_data.extend_from_slice(&VERIFICATION_TYPE);
+    world_id_cpi_data.extend_from_slice(&signal_hash);
+    world_id_cpi_data.extend_from_slice(&external_nullifier_hash);
+    world_id_cpi_data.extend_from_slice(proof);
+
+    let world_id_cpi_instruction = Instruction {
+        program_id: SOLANA_WORLD_ID_PROGRAM,
+        accounts: vec![
+            AccountMeta::new_readonly(*world_id_root.key, false),
+            AccountMeta::new_readonly(*world_id_latest_root.key, false),
+            AccountMeta::new_readonly(*world_id_config.key, false),
+        ],
+        data: world_id_cpi_data,
+    };
+
+    invoke_verified(
+        &world_id_cpi_instruction,
+        &[&world_id_program, &world_id_root, &world_id_latest_root, &world_id_config],
+    )?;
+
+    // 3. update user data
 
     // scoping to prevent reborrowing issues
     let verified_humans;

--- a/comptoken/src/comptoken.rs
+++ b/comptoken/src/comptoken.rs
@@ -1,6 +1,7 @@
 mod comptoken_proof;
 mod constants;
 mod global_data;
+mod verification_repeat_protection;
 mod verify_accounts;
 
 extern crate bs58;
@@ -33,6 +34,7 @@ use comptoken_utils::{
 use comptoken_proof::ComptokenProof;
 use constants::*;
 use global_data::{daily_distribution_data::DailyDistributionValues, GlobalData};
+use verification_repeat_protection::WorldIdNullifiers;
 use verify_accounts::*;
 
 // declare and export the program's entrypoint
@@ -675,7 +677,7 @@ pub fn verify_human(program_id: &Pubkey, accounts: &[AccountInfo], instruction_d
             world_id_root: Some((&root_hash, (false, false))),
             world_id_latest_root: Some((VERIFICATION_TYPE, (false, false))),
             world_id_config: Some((false, false)),
-            world_id_nullifier: Some((&nullifier_hash, (false, false))),
+            nullifier_storage_account: Some((&nullifier_hash, (false, true))),
             solana_token_2022_program: Some((false, false)),
             ..Default::default()
         },
@@ -695,12 +697,13 @@ pub fn verify_human(program_id: &Pubkey, accounts: &[AccountInfo], instruction_d
     let world_id_root = verified_accounts.world_id_root.unwrap();
     let world_id_latest_root = verified_accounts.world_id_latest_root.unwrap();
     let world_id_config = verified_accounts.world_id_config.unwrap();
-    let world_id_nullifier = verified_accounts.world_id_nullifier.unwrap();
+    let mut nullifier_storage_account = verified_accounts.nullifier_storage_account.unwrap();
 
     // 1. verify unique nullifier hash
-
-    // TODO
     // TODO what to do when people die?
+
+    let nulllifier_storage = WorldIdNullifiers::from_verified_account_mut(&mut nullifier_storage_account);
+    nulllifier_storage.insert(&nullifier_hash).expect("nullifier hash to be unique");
 
     // 2. cpi to world id program
     const APP_ID: &str = "comptoken";

--- a/comptoken/src/comptoken.rs
+++ b/comptoken/src/comptoken.rs
@@ -653,6 +653,11 @@ pub fn verify_human(program_id: &Pubkey, accounts: &[AccountInfo], _instruction_
             user_data: Some((true, (false, true))),
             transfer_hook_program: Some((false, false)),
             extra_account_metas: Some((false, false)),
+            world_id_program: Some((false, false)),
+            world_id_root: Some((&root_hash, (false, false))),
+            world_id_latest_root: Some((VERIFICATION_TYPE, (false, false))),
+            world_id_config: Some((false, false)),
+            world_id_nullifier: Some((&nullifier_hash, (false, false))),
             solana_token_2022_program: Some((false, false)),
             ..Default::default()
         },
@@ -667,6 +672,11 @@ pub fn verify_human(program_id: &Pubkey, accounts: &[AccountInfo], _instruction_
     let user_data_account = verified_accounts.user_data.unwrap();
     let transfer_hook_program = verified_accounts.transfer_hook_program.unwrap();
     let extra_account_metas_account = verified_accounts.extra_account_metas.unwrap();
+    let world_id_program = verified_accounts.world_id_program.unwrap();
+    let world_id_root = verified_accounts.world_id_root.unwrap();
+    let world_id_latest_root = verified_accounts.world_id_latest_root.unwrap();
+    let world_id_config = verified_accounts.world_id_config.unwrap();
+    let world_id_nullifier = verified_accounts.world_id_nullifier.unwrap();
 
     todo!("cpi to worldcoin to verify human");
     // TODO

--- a/comptoken/src/comptoken.rs
+++ b/comptoken/src/comptoken.rs
@@ -25,7 +25,7 @@ use spl_token_2022::{
 };
 
 use comptoken_utils::{
-    create_pda, get_current_time, invoke_signed_verified, normalize_time,
+    create_pda, get_current_time, invoke_signed_verified, invoke_verified, normalize_time,
     user_data::{UserData, USER_DATA_MIN_SIZE},
     SEC_PER_DAY,
 };
@@ -822,4 +822,23 @@ fn init_comptoken_account<'a>(
 fn store_hash(proof: ComptokenProof, data_account: &VerifiedAccountInfo) {
     let user_data: &mut UserData = data_account.into();
     user_data.insert(&proof.hash, &proof.recent_block_hash)
+}
+
+fn hash_to_field(val: &[u8]) -> [u8; 32] {
+    let mut hash_result = hash::hash(val).to_bytes();
+    hash_result[0] = 0;
+    hash_result.rotate_right(1);
+    hash_result
+}
+
+fn app_id_to_external_nullifier_hash(app_id: &str, action: &str) -> [u8; 32] {
+    let app_hash = hash_to_field(app_id.as_bytes());
+    let mut combined = app_hash.to_vec();
+    combined.extend_from_slice(action.as_bytes());
+    hash_to_field(&combined)
+}
+
+fn get_next_data<'a, T>(data: &'a [u8], size: usize, converter: impl FnOnce(&'a [u8]) -> T) -> (T, &[u8]) {
+    let (data, rest) = data.split_at(size);
+    (converter(data), rest)
 }

--- a/comptoken/src/constants.rs
+++ b/comptoken/src/constants.rs
@@ -1,3 +1,5 @@
+use solana_program::{pubkey, pubkey::Pubkey};
+
 // TODO: This number deserves scrutiny and justification.
 pub const COMPTOKEN_DISTRIBUTION_MULTIPLIER: u64 = 146_000;
 
@@ -25,3 +27,5 @@ pub const COMPTOKEN_ACCOUNT_SPACE: u64 = 256; // TODO: get actual size
 pub const FUTURE_UBI_VERIFIED_HUMANS: u64 = 1_000_000_000;
 
 pub const MINING_AMOUNT: u64 = 10000;
+
+pub const SOLANA_WORLD_ID_PROGRAM: Pubkey = pubkey!("9QwAWx3TKg4CaTjHNhBefQeNSzEKDe2JDxL46F76tVDv");

--- a/comptoken/src/verification_repeat_protection.rs
+++ b/comptoken/src/verification_repeat_protection.rs
@@ -1,0 +1,83 @@
+// store the nullifiers of the world id verification process to prevent a user from verifying twice
+use comptoken_utils::verify_accounts::VerifiedAccountInfo;
+use solana_program::{hash::Hash, pubkey::Pubkey};
+
+#[repr(align(32))]
+struct WorldIdNullifiersMeta {
+    size: usize,
+    _padding: [u8; 24],
+}
+
+pub struct WorldIdNullifiers {
+    meta: WorldIdNullifiersMeta,
+    nullifiers: [Hash; Self::SIZE],
+}
+
+impl WorldIdNullifiers {
+    const SIZE: usize = 10_240 - std::mem::size_of::<WorldIdNullifiersMeta>() / std::mem::size_of::<Hash>(); // 10_240 is the max size of an account on Solana (is there overhead (i.e. owner, executable, lamports) that needs to be accounted for?)
+
+    /// # Safety
+    ///
+    /// The caller must ensure that the account is actually a valid WorldIdNullifiers
+    pub fn from_verified_account<'a>(account: &VerifiedAccountInfo<'a>) -> &'a Self {
+        let data = account.try_borrow_data().unwrap();
+        data.as_ref().into()
+    }
+
+    /// # Safety
+    ///
+    /// The caller must ensure that the account is actually a valid WorldIdNullifiers
+    pub fn from_verified_account_mut<'a>(account: &mut VerifiedAccountInfo<'a>) -> &'a mut Self {
+        let mut data = account.try_borrow_mut_data().unwrap();
+        data.as_mut().into()
+    }
+
+    /// Get the seeds that should be used to derive the account
+    fn get_seeds(nullifier: &Hash) -> Vec<&[u8]> {
+        vec![b"NullifierStorage_1", &nullifier.as_ref()[..4]] // TODO: are these the correct seeds?
+    }
+
+    /// Get the account that should be used to store the nullifier
+    ///
+    /// The account should be a PDA with seeds that are derived from the nullifier
+    /// (TODO: should it be a single account or a list of accounts?)
+    pub fn get_account(program_id: &Pubkey, nullifier: &Hash) -> Pubkey {
+        Pubkey::find_program_address(&Self::get_seeds(nullifier), program_id).0
+    }
+
+    /// Insert a nullifier into the list, return None if the nullifier already exists
+    pub fn insert(&mut self, nullifier: &Hash) -> Option<()> {
+        // TODO: better way to insert nullifiers/ check if nullifier already exists
+        if self.nullifiers.iter().take(self.meta.size).any(|n| n == nullifier) {
+            None
+        } else {
+            if self.meta.size == Self::SIZE {
+                // TODO: make this not possible/handle this case
+                panic!("WorldIdNullifiers is full");
+            }
+            self.nullifiers[self.meta.size] = *nullifier;
+            self.meta.size += 1;
+            Some(())
+        }
+    }
+}
+
+impl From<&[u8]> for &WorldIdNullifiers {
+    /// # Safety
+    ///
+    /// The caller must ensure that the data is actually a valid WorldIdNullifiers
+    fn from(data: &[u8]) -> Self {
+        assert!(data.len() == std::mem::size_of::<Self>());
+        unsafe { &*(data.as_ptr().cast()) }
+    }
+}
+
+impl From<&mut [u8]> for &mut WorldIdNullifiers {
+    /// # Safety
+    ///
+    /// The caller must ensure that the data is actually a valid WorldIdNullifiers
+    fn from(data: &mut [u8]) -> Self {
+        assert!(data.len() == std::mem::size_of::<Self>());
+        unsafe { &mut *(data.as_mut_ptr().cast()) }
+    }
+}

--- a/comptoken/src/verify_accounts.rs
+++ b/comptoken/src/verify_accounts.rs
@@ -174,7 +174,7 @@ fn verify_solana_token_2022_program<'a>(account: &AccountInfo<'a>) -> VerifiedAc
 pub type SignerAndWritable = (bool, bool);
 
 #[derive(Default)]
-pub struct AccountsToVerify {
+pub struct AccountsToVerify<'a> {
     pub payer: Option<SignerAndWritable>,
     pub comptoken_program: Option<SignerAndWritable>,
     pub comptoken_mint: Option<SignerAndWritable>,

--- a/comptoken/src/verify_accounts.rs
+++ b/comptoken/src/verify_accounts.rs
@@ -2,15 +2,19 @@ use spl_token_2022::{
     extension::StateWithExtensions,
     solana_program::{
         account_info::{next_account_info, AccountInfo},
+        hash::Hash,
         program_error::ProgramError,
         pubkey::Pubkey,
     },
     state::Account,
 };
 
-use crate::generated::{
-    COMPTOKEN_MINT_ADDRESS, COMPTO_FUTURE_UBI_BANK_ACCOUNT_SEEDS, COMPTO_GLOBAL_DATA_ACCOUNT_SEEDS,
-    COMPTO_INTEREST_BANK_ACCOUNT_SEEDS, COMPTO_VERIFIED_HUMAN_UBI_BANK_ACCOUNT_SEEDS, TRANSFER_HOOK_ID,
+use crate::{
+    generated::{
+        COMPTOKEN_MINT_ADDRESS, COMPTO_FUTURE_UBI_BANK_ACCOUNT_SEEDS, COMPTO_GLOBAL_DATA_ACCOUNT_SEEDS,
+        COMPTO_INTEREST_BANK_ACCOUNT_SEEDS, COMPTO_VERIFIED_HUMAN_UBI_BANK_ACCOUNT_SEEDS, TRANSFER_HOOK_ID,
+    },
+    SOLANA_WORLD_ID_PROGRAM,
 };
 
 pub use comptoken_utils::verify_accounts::VerifiedAccountInfo;
@@ -123,6 +127,37 @@ pub fn verify_transfer_hook_program<'a>(account: &AccountInfo<'a>) -> VerifiedAc
     VerifiedAccountInfo::verify_specific_address(account, &TRANSFER_HOOK_ID, false, false)
 }
 
+pub fn verify_world_id_program<'a>(account: &AccountInfo<'a>) -> VerifiedAccountInfo<'a> {
+    VerifiedAccountInfo::verify_specific_address(account, &SOLANA_WORLD_ID_PROGRAM, false, false)
+}
+
+pub fn verify_world_id_root<'a>(account: &AccountInfo<'a>, root_hash: &Hash) -> VerifiedAccountInfo<'a> {
+    VerifiedAccountInfo::verify_pda(account, &SOLANA_WORLD_ID_PROGRAM, &[b"Root", root_hash.as_ref()], false, false).0
+}
+
+pub fn verify_world_id_latest_root<'a>(
+    account: &AccountInfo<'a>, verification_type: [u8; 1],
+) -> VerifiedAccountInfo<'a> {
+    VerifiedAccountInfo::verify_pda(
+        account,
+        &SOLANA_WORLD_ID_PROGRAM,
+        &[b"LatestRoot", &verification_type],
+        false,
+        false,
+    )
+    .0
+}
+
+pub fn verify_world_id_config<'a>(account: &AccountInfo<'a>) -> VerifiedAccountInfo<'a> {
+    VerifiedAccountInfo::verify_pda(account, &SOLANA_WORLD_ID_PROGRAM, &[b"Config"], false, false).0
+}
+
+pub fn verify_world_id_nullifier<'a>(
+    account: &AccountInfo<'a>, program_id: &Pubkey, nullifier_hash: &Hash,
+) -> VerifiedAccountInfo<'a> {
+    VerifiedAccountInfo::verify_pda(account, program_id, &[b"Nullifier", nullifier_hash.as_ref()], false, false).0
+}
+
 pub fn verify_solana_program<'a>(account: &AccountInfo<'a>) -> VerifiedAccountInfo<'a> {
     VerifiedAccountInfo::verify_specific_address(
         account,
@@ -155,6 +190,11 @@ pub struct AccountsToVerify {
     pub user_data: Option<(bool, SignerAndWritable)>, // (isCreated, (needsSigner, needsWritable)),
     pub transfer_hook_program: Option<SignerAndWritable>,
     pub extra_account_metas: Option<SignerAndWritable>,
+    pub world_id_program: Option<SignerAndWritable>,
+    pub world_id_root: Option<(&'a Hash, SignerAndWritable)>, // (rootHash, (needsSigner, needsWritable)),
+    pub world_id_latest_root: Option<([u8; 1], SignerAndWritable)>, // (verificationType, (needsSigner, needsWritable)),
+    pub world_id_config: Option<SignerAndWritable>,
+    pub world_id_nullifier: Option<(&'a Hash, SignerAndWritable)>, // (nullifierHash, (needsSigner, needsWritable)),
     pub solana_program: Option<SignerAndWritable>,
     pub solana_token_2022_program: Option<SignerAndWritable>,
     pub slothashes: Option<SignerAndWritable>,
@@ -177,6 +217,11 @@ pub struct VerifiedAccounts<'a> {
     pub user_data_bump: Option<u8>,
     pub transfer_hook_program: Option<VerifiedAccountInfo<'a>>,
     pub extra_account_metas: Option<VerifiedAccountInfo<'a>>,
+    pub world_id_program: Option<VerifiedAccountInfo<'a>>,
+    pub world_id_root: Option<VerifiedAccountInfo<'a>>,
+    pub world_id_latest_root: Option<VerifiedAccountInfo<'a>>,
+    pub world_id_config: Option<VerifiedAccountInfo<'a>>,
+    pub world_id_nullifier: Option<VerifiedAccountInfo<'a>>,
     pub solana_program: Option<VerifiedAccountInfo<'a>>,
     pub solana_token_2022_program: Option<VerifiedAccountInfo<'a>>,
     pub slothashes: Option<VerifiedAccountInfo<'a>>,
@@ -286,6 +331,26 @@ pub fn verify_accounts<'a>(
         )
     });
 
+    let world_id_program = accounts_to_verify
+        .world_id_program
+        .map(|_| verify_world_id_program(next_account_info(account_info_iter).unwrap()));
+
+    let world_id_root = accounts_to_verify
+        .world_id_root
+        .map(|(root_hash, _)| verify_world_id_root(next_account_info(account_info_iter).unwrap(), root_hash));
+
+    let world_id_latest_root = accounts_to_verify.world_id_latest_root.map(|(verification_type, _)| {
+        verify_world_id_latest_root(next_account_info(account_info_iter).unwrap(), verification_type)
+    });
+
+    let world_id_config = accounts_to_verify
+        .world_id_config
+        .map(|_| verify_world_id_config(next_account_info(account_info_iter).unwrap()));
+
+    let world_id_nullifier = accounts_to_verify.world_id_nullifier.map(|(nullifier_hash, _)| {
+        verify_world_id_nullifier(next_account_info(account_info_iter).unwrap(), program_id, nullifier_hash)
+    });
+
     let solana_program = accounts_to_verify
         .solana_program
         .map(|_| verify_solana_program(next_account_info(account_info_iter).unwrap()));
@@ -313,6 +378,11 @@ pub fn verify_accounts<'a>(
         user_data_bump,
         transfer_hook_program,
         extra_account_metas,
+        world_id_program,
+        world_id_root,
+        world_id_latest_root,
+        world_id_config,
+        world_id_nullifier,
         solana_program,
         solana_token_2022_program,
         slothashes,

--- a/comptoken/src/verify_accounts.rs
+++ b/comptoken/src/verify_accounts.rs
@@ -14,6 +14,7 @@ use crate::{
         COMPTOKEN_MINT_ADDRESS, COMPTO_FUTURE_UBI_BANK_ACCOUNT_SEEDS, COMPTO_GLOBAL_DATA_ACCOUNT_SEEDS,
         COMPTO_INTEREST_BANK_ACCOUNT_SEEDS, COMPTO_VERIFIED_HUMAN_UBI_BANK_ACCOUNT_SEEDS, TRANSFER_HOOK_ID,
     },
+    verification_repeat_protection::WorldIdNullifiers,
     SOLANA_WORLD_ID_PROGRAM,
 };
 
@@ -152,10 +153,15 @@ pub fn verify_world_id_config<'a>(account: &AccountInfo<'a>) -> VerifiedAccountI
     VerifiedAccountInfo::verify_pda(account, &SOLANA_WORLD_ID_PROGRAM, &[b"Config"], false, false).0
 }
 
-pub fn verify_world_id_nullifier<'a>(
+pub fn verify_nullifier_storage<'a>(
     account: &AccountInfo<'a>, program_id: &Pubkey, nullifier_hash: &Hash,
 ) -> VerifiedAccountInfo<'a> {
-    VerifiedAccountInfo::verify_pda(account, program_id, &[b"Nullifier", nullifier_hash.as_ref()], false, false).0
+    VerifiedAccountInfo::verify_specific_address(
+        account,
+        &WorldIdNullifiers::get_account(program_id, nullifier_hash),
+        false,
+        true,
+    )
 }
 
 pub fn verify_solana_program<'a>(account: &AccountInfo<'a>) -> VerifiedAccountInfo<'a> {
@@ -194,7 +200,7 @@ pub struct AccountsToVerify<'a> {
     pub world_id_root: Option<(&'a Hash, SignerAndWritable)>, // (rootHash, (needsSigner, needsWritable)),
     pub world_id_latest_root: Option<([u8; 1], SignerAndWritable)>, // (verificationType, (needsSigner, needsWritable)),
     pub world_id_config: Option<SignerAndWritable>,
-    pub world_id_nullifier: Option<(&'a Hash, SignerAndWritable)>, // (nullifierHash, (needsSigner, needsWritable)),
+    pub nullifier_storage_account: Option<(&'a Hash, SignerAndWritable)>, // (nullifierHash, (needsSigner, needsWritable)),
     pub solana_program: Option<SignerAndWritable>,
     pub solana_token_2022_program: Option<SignerAndWritable>,
     pub slothashes: Option<SignerAndWritable>,
@@ -221,7 +227,7 @@ pub struct VerifiedAccounts<'a> {
     pub world_id_root: Option<VerifiedAccountInfo<'a>>,
     pub world_id_latest_root: Option<VerifiedAccountInfo<'a>>,
     pub world_id_config: Option<VerifiedAccountInfo<'a>>,
-    pub world_id_nullifier: Option<VerifiedAccountInfo<'a>>,
+    pub nullifier_storage_account: Option<VerifiedAccountInfo<'a>>,
     pub solana_program: Option<VerifiedAccountInfo<'a>>,
     pub solana_token_2022_program: Option<VerifiedAccountInfo<'a>>,
     pub slothashes: Option<VerifiedAccountInfo<'a>>,
@@ -347,8 +353,8 @@ pub fn verify_accounts<'a>(
         .world_id_config
         .map(|_| verify_world_id_config(next_account_info(account_info_iter).unwrap()));
 
-    let world_id_nullifier = accounts_to_verify.world_id_nullifier.map(|(nullifier_hash, _)| {
-        verify_world_id_nullifier(next_account_info(account_info_iter).unwrap(), program_id, nullifier_hash)
+    let nullifier_storage_account = accounts_to_verify.nullifier_storage_account.map(|(nullifier_hash, _)| {
+        verify_nullifier_storage(next_account_info(account_info_iter).unwrap(), program_id, nullifier_hash)
     });
 
     let solana_program = accounts_to_verify
@@ -382,7 +388,7 @@ pub fn verify_accounts<'a>(
         world_id_root,
         world_id_latest_root,
         world_id_config,
-        world_id_nullifier,
+        nullifier_storage_account,
         solana_program,
         solana_token_2022_program,
         slothashes,


### PR DESCRIPTION
store each nullifier in accounts to prevent reuse

pros
- ~3x more "space" effecient (cost/nullifier stored)
- fewer pda's

cons
- more complicated
- possibly difficult to grow
- likely O(log(n)) lookup (still relatively small, log[2](7 billion) ~= 40)